### PR TITLE
Update datausa.io API Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This quest consists of 4 different parts. Putting all 4 parts together we will h
 
 #### Part 2: APIs
 1. Create a script that will fetch data from [this API](https://honolulu-api.datausa.io/tesseract/data.jsonrecords?cube=acs_yg_total_population_1&drilldowns=Year%2CNation&locale=en&measures=Population).
-   You can read the documentation [here](https://datausa.io/about/api/)
+   You can read the documentation [here](https://datausa.io/about/api/).
 2. Save the result of this API call as a JSON file in S3.
 
 #### Part 3: Data Analytics

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This quest consists of 4 different parts. Putting all 4 parts together we will h
     - Ensure the script doesn't upload the same file more than once.
 
 #### Part 2: APIs
-1. Create a script that will fetch data from [this API](https://datausa.io/api/data?drilldowns=Nation&measures=Population).
+1. Create a script that will fetch data from [this API](https://honolulu-api.datausa.io/tesseract/data.jsonrecords?cube=acs_yg_total_population_1&drilldowns=Year%2CNation&locale=en&measures=Population).
    You can read the documentation [here](https://datausa.io/about/api/)
 2. Save the result of this API call as a JSON file in S3.
 


### PR DESCRIPTION
An applicant noticed that the link provided in part 2 of the Quest readme resolves in a 404 response. Kevin Formsma shared a new link to the data and after he noticed that datausa.io updated their frontend [here](https://github.com/DataUSA/datausa-site/pull/1149). This PR is to update the quest readme with the new [API URL](https://honolulu-api.datausa.io/tesseract/data.jsonrecords?cube=acs_yg_total_population_1&drilldowns=Year%2CNation&locale=en&measures=Population).